### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,15 +33,15 @@ hashring
     :alt: PyPI Package monthly downloads
     :target: https://pypi.python.org/pypi/hashring
 
-.. |wheel| image:: https://pypip.in/wheel/hashring/badge.png?style=flat
+.. |wheel| image:: https://img.shields.io/pypi/wheel/hashring.svg?style=flat
     :alt: PyPI Wheel
     :target: https://pypi.python.org/pypi/hashring
 
-.. |supported-versions| image:: https://pypip.in/py_versions/hashring/badge.png?style=flat
+.. |supported-versions| image:: https://img.shields.io/pypi/pyversions/hashring.svg?style=flat
     :alt: Supported versions
     :target: https://pypi.python.org/pypi/hashring
 
-.. |supported-implementations| image:: https://pypip.in/implementation/hashring/badge.png?style=flat
+.. |supported-implementations| image:: https://img.shields.io/pypi/implementation/hashring.svg?style=flat
     :alt: Supported imlementations
     :target: https://pypi.python.org/pypi/hashring
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20hashring))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `hashring`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.